### PR TITLE
feat: add iOS 26 sharedBackgroundHidden support for avatar toolbar items

### DIFF
--- a/Proto/Extensions/View+Extensions.swift
+++ b/Proto/Extensions/View+Extensions.swift
@@ -1,0 +1,22 @@
+//
+//  View+Extensions.swift
+//  Proto
+//
+//  Created by Dave Morgan on 18/09/2025.
+//
+
+import SwiftUI
+
+// MARK: - Shared Background Visibility
+extension ToolbarContent {
+    @ToolbarContentBuilder
+    public func sharedBackgroundHidden() -> some ToolbarContent {
+        if #available(iOS 26.0, *) {
+            // Remove the iOS 26 glass effect from the toolbar content
+            self
+                .sharedBackgroundVisibility(.hidden)
+        } else {
+            self
+        }
+    }
+}

--- a/Proto/Views/Tabs/CommunityTab.swift
+++ b/Proto/Views/Tabs/CommunityTab.swift
@@ -139,6 +139,7 @@ struct CommunityTab: View {
                         selectedTintColor: $selectedTintColor
                     )
                 }
+                .sharedBackgroundHidden()
             }
         }
         .sheet(isPresented: $showDraftsSheet) {

--- a/Proto/Views/Tabs/MessagesTab.swift
+++ b/Proto/Views/Tabs/MessagesTab.swift
@@ -94,6 +94,7 @@ struct MessagesTab: View {
                         selectedTintColor: $selectedTintColor
                     )
                 }
+                .sharedBackgroundHidden()
             }
         }
     }

--- a/Proto/Views/Tabs/NotificationsTab.swift
+++ b/Proto/Views/Tabs/NotificationsTab.swift
@@ -204,6 +204,7 @@ struct NotificationsTab: View {
                             .clipShape(Circle())
                     }
                 }
+                .sharedBackgroundHidden()
             }
         }
         .sheet(isPresented: $showingManageNotifications) {

--- a/Proto/Views/Tabs/SearchTab.swift
+++ b/Proto/Views/Tabs/SearchTab.swift
@@ -33,6 +33,7 @@ struct SearchTab: View {
                         selectedTintColor: $selectedTintColor
                     )
                 }
+                .sharedBackgroundHidden()
             }
             .searchToolbarBehavior(.automatic)
         }


### PR DESCRIPTION
## Overview
This PR adds iOS 26 compatibility for avatar toolbar items by removing the glass effect that appears on iOS 26.

## Changes Made
- Added View+Extensions.swift: Contains the sharedBackgroundHidden() extension for iOS 26 compatibility
- Applied sharedBackgroundHidden() to all avatar toolbar items:
  - CommunityTab: Applied to PrimaryMenu toolbar item
  - MessagesTab: Applied to ProfileMenu toolbar item  
  - NotificationsTab: Applied to custom Menu toolbar item
  - SearchTab: Applied to ProfileMenu toolbar item

## Technical Details
- Uses the same approach as the discovery-proto repo for consistency
- Removes the iOS 26 glass effect from avatar toolbar items for better visual integration
- Maintains all existing functionality while improving iOS 26 appearance
- Minimal changes - just adding the modifier to existing toolbar items

## Testing
- Builds successfully on iOS 26 simulator
- All existing functionality preserved
- Visual improvement on iOS 26 devices

## Related
- Matches implementation from discovery-proto repo
- Addresses iOS 26 visual inconsistencies with toolbar items